### PR TITLE
Backport to contao 4.4 and php 7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,11 @@ Name | Example
 -----|--------
 `{{watchlist_add_item_link::file::<file uuid (string)>::<optional: title>::<optional: watch list uuid>}}` | `{{watchlist_add_item_link::file::2e6b6f54-e4af-11eb-b4fc-001e678385c6}}`
 `{{watchlist_add_item_link::entity::<entity table>::<entity id>::<title>::<optional: entity url>::<optional: preview file uuid (string)>::<optional: watch list uuid>}}` | `{{watchlist_add_item_link::entity::tl_news::1::My headline::https://example.org/my-entity::2e6b6f54-e4af-11eb-b4fc-001e678385c6}}`
+
+## Developers
+
+### Events
+
+| Event                   | Description                                                      |
+|-------------------------|------------------------------------------------------------------|
+| WatchlistItemDataEvent | Modify the watchlist item before output to the watchlist module. |

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "preferred-install": "dist"
     },
     "extra": {
-        "contao-manager-plugin": "HeimrichHannot\\WatchlistBundle\\ContaoManager\\Plugin"
+        "contao-manager-plugin": "HeimrichHannot\\WatchlistBundle\\ContaoManager\\Plugin",
+        "foxy": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,17 @@
         "issues": "https://github.com/heimrichhannot/contao-watchlist-bundle/issues"
     },
     "require": {
-        "php": "^7.4",
+        "php": "^7.3 || ^8.0",
         "ext-zip": "*",
-        "contao/core-bundle": "^4.9",
+        "contao/core-bundle": "^4.4",
         "heimrichhannot/contao-utils-bundle": "^2.199",
         "heimrichhannot/contao-inserttagcollection-bundle": "^1.1",
         "heimrichhannot/contao-request-bundle": "^1.2",
-        "symfony/config": "^4.4",
-        "symfony/dependency-injection": "^4.4",
-        "symfony/http-foundation": "^4.4",
-        "symfony/http-kernel": "^4.4",
-        "symfony/routing": "^4.4"
+        "symfony/config": "^3.4 || ^4.4",
+        "symfony/dependency-injection": "^3.4 || ^4.4",
+        "symfony/http-foundation": "^3.4 || ^4.4",
+        "symfony/http-kernel": "^3.4 || ^4.4",
+        "symfony/routing": "^3.4 || ^4.4"
     },
     "require-dev": {
         "contao/test-case": "1.1.*",

--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -46,6 +46,10 @@ class Plugin implements BundlePluginInterface, ConfigPluginInterface, RoutingPlu
         if (class_exists('HeimrichHannot\EncoreBundle\HeimrichHannotContaoEncoreBundle')) {
             $loader->load('@HeimrichHannotWatchlistBundle/Resources/config/config_encore.yml');
         }
+
+        if (class_exists('Contao\CoreBundle\Migration\AbstractMigration')) {
+            $loader->load('@HeimrichHannotWatchlistBundle/Resources/config/services_migration.yml');
+        }
     }
 
     public function getRouteCollection(LoaderResolverInterface $resolver, KernelInterface $kernel)

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -33,13 +33,26 @@ class AjaxController
     const WATCHLIST_CONTENT_URI = '/_huh_watchlist/content';
     const WATCHLIST_ITEM_URI = '/_huh_watchlist/item';
 
-    protected ContaoFramework    $framework;
-    protected DatabaseUtil       $databaseUtil;
-    protected WatchlistUtil      $watchlistUtil;
-    protected ModelUtil          $modelUtil;
-    protected SessionInterface   $session;
-    protected ContainerInterface $container;
-    protected FileUtil           $fileUtil;
+    /** @var ContaoFramework */
+    protected $framework;
+
+    /** @var DatabaseUtil */
+    protected $databaseUtil;
+
+    /** @var WatchlistUtil */
+    protected $watchlistUtil;
+
+    /** @var ModelUtil */
+    protected $modelUtil;
+
+    /** @var SessionInterface */
+    protected $session;
+
+    /** @var ContainerInterface */
+    protected $container;
+
+    /** @var FileUtil */
+    protected $fileUtil;
 
     public function __construct(
         ContainerInterface $container,

--- a/src/Controller/FrontendModule/ShareListModuleController.php
+++ b/src/Controller/FrontendModule/ShareListModuleController.php
@@ -26,19 +26,32 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @FrontendModule(ShareListModuleController::TYPE,category="miscellaneous")
+ * FrontendModule(ShareListModuleController::TYPE,category="miscellaneous")
  */
-class ShareListModuleController extends AbstractFrontendModuleController
+class ShareListModuleController
 {
     const TYPE = 'watchlist_share_list';
 
-    protected ContaoFramework $framework;
-    protected DatabaseUtil    $databaseUtil;
-    protected WatchlistUtil   $watchlistUtil;
-    protected UrlUtil         $urlUtil;
-    protected FileUtil        $fileUtil;
-    protected ImageUtil       $imageUtil;
-    protected ModelUtil       $modelUtil;
+    /** @var ContaoFramework */
+    protected $framework;
+
+    /** @var DatabaseUtil */
+    protected $databaseUtil;
+
+    /** @var WatchlistUtil */
+    protected $watchlistUtil;
+
+    /** @var UrlUtil */
+    protected $urlUtil;
+
+    /** @var FileUtil */
+    protected $fileUtil;
+
+    /** @var ImageUtil */
+    protected $imageUtil;
+
+    /** @var ModelUtil */
+    protected $modelUtil;
 
     public function __construct(
         ContaoFramework $framework,
@@ -58,7 +71,7 @@ class ShareListModuleController extends AbstractFrontendModuleController
         $this->modelUtil = $modelUtil;
     }
 
-    protected function getResponse(Template $template, ModuleModel $module, Request $request): ?Response
+    public function getResponse(Template $template, ModuleModel $module, Request $request): ?Response
     {
         if (!($watchlistUuid = $request->get('watchlist'))) {
             $template->watchlistNotFound = true;
@@ -131,6 +144,8 @@ class ShareListModuleController extends AbstractFrontendModuleController
 
         $template->items = $items;
 
-        return $template->getResponse();
+        return null;
+
+//        return $template->getResponse();
     }
 }

--- a/src/Controller/FrontendModule/WatchlistModuleController.php
+++ b/src/Controller/FrontendModule/WatchlistModuleController.php
@@ -13,7 +13,9 @@ use Contao\CoreBundle\ServiceAnnotation\FrontendModule;
 use Contao\Environment;
 use Contao\FrontendTemplate;
 use Contao\ModuleModel;
+use Contao\System;
 use Contao\Template;
+use HeimrichHannot\EncoreBundle\Asset\FrontendAsset;
 use HeimrichHannot\UtilsBundle\Database\DatabaseUtil;
 use HeimrichHannot\UtilsBundle\File\FileUtil;
 use HeimrichHannot\UtilsBundle\Url\UrlUtil;
@@ -24,16 +26,22 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 /**
- * @FrontendModule(WatchlistModuleController::TYPE,category="miscellaneous")
+ * FrontendModule(WatchlistModuleController::TYPE,category="miscellaneous")
  */
-class WatchlistModuleController extends AbstractFrontendModuleController
+class WatchlistModuleController
 {
     const TYPE = 'watchlist';
-    protected DatabaseUtil     $databaseUtil;
-    protected WatchlistUtil    $watchlistUtil;
-    protected UrlUtil          $urlUtil;
-    protected FileUtil         $fileUtil;
-    protected SessionInterface $session;
+
+    /** @var DatabaseUtil */
+    protected $databaseUtil;
+    /** @var WatchlistUtil */
+    protected $watchlistUtil;
+    /** @var UrlUtil */
+    protected $urlUtil;
+    /** @var FileUtil */
+    protected $fileUtil;
+    /** @var SessionInterface */
+    protected $session;
 
     public function __construct(DatabaseUtil $databaseUtil, WatchlistUtil $watchlistUtil, UrlUtil $urlUtil, FileUtil $fileUtil, SessionInterface $session)
     {
@@ -47,8 +55,8 @@ class WatchlistModuleController extends AbstractFrontendModuleController
     protected function getResponse(Template $template, ModuleModel $module, Request $request): ?Response
     {
         // load js assets
-        if ($this->container->has('HeimrichHannot\EncoreBundle\Asset\FrontendAsset')) {
-            $this->container->get(\HeimrichHannot\EncoreBundle\Asset\FrontendAsset::class)->addActiveEntrypoint('contao-watchlist-bundle');
+        if (System::getContainer()->has('HeimrichHannot\EncoreBundle\Asset\FrontendAsset')) {
+            System::getContainer()->get(FrontendAsset::class)->addActiveEntrypoint('contao-watchlist-bundle');
         } else {
             $GLOBALS['TL_JAVASCRIPT']['contao-watchlist-bundle'] = 'bundles/heimrichhannotwatchlistbundle/assets/contao-watchlist-bundle.js|static';
         }
@@ -74,6 +82,6 @@ class WatchlistModuleController extends AbstractFrontendModuleController
             new FrontendTemplate($config->watchlistContentTemplate ?: 'watchlist_content_default'), $currentUrl, $objPage->rootId, $config, $watchlist
         );
 
-        return $template->getResponse();
+//        return $template->getResponse();
     }
 }

--- a/src/Controller/FrontendModule/WatchlistModuleController.php
+++ b/src/Controller/FrontendModule/WatchlistModuleController.php
@@ -52,7 +52,7 @@ class WatchlistModuleController
         $this->session = $session;
     }
 
-    protected function getResponse(Template $template, ModuleModel $module, Request $request): ?Response
+    public function getResponse(Template $template, ModuleModel $module, Request $request): ?Response
     {
         // load js assets
         if (System::getContainer()->has('HeimrichHannot\EncoreBundle\Asset\FrontendAsset')) {
@@ -81,6 +81,8 @@ class WatchlistModuleController
         $template->watchlistContent = $this->watchlistUtil->parseWatchlistContent(
             new FrontendTemplate($config->watchlistContentTemplate ?: 'watchlist_content_default'), $currentUrl, $objPage->rootId, $config, $watchlist
         );
+
+        return null;
 
 //        return $template->getResponse();
     }

--- a/src/DataContainer/WatchlistConfigContainer.php
+++ b/src/DataContainer/WatchlistConfigContainer.php
@@ -17,9 +17,12 @@ use HeimrichHannot\UtilsBundle\Dca\DcaUtil;
 
 class WatchlistConfigContainer
 {
-    protected ContaoFramework     $framework;
-    protected DcaUtil             $dcaUtil;
-    protected TwigTemplateLocator $twigTemplateLocator;
+    /** @var ContaoFramework */
+    protected $framework;
+    /** @var DcaUtil */
+    protected $dcaUtil;
+    /** @var TwigTemplateLocator */
+    protected $twigTemplateLocator;
 
     public function __construct(ContaoFramework $framework, DcaUtil $dcaUtil, TwigTemplateLocator $twigTemplateLocator)
     {

--- a/src/DataContainer/WatchlistConfigContainer.php
+++ b/src/DataContainer/WatchlistConfigContainer.php
@@ -10,7 +10,6 @@ namespace HeimrichHannot\WatchlistBundle\DataContainer;
 
 use Contao\Controller;
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use HeimrichHannot\TwigSupportBundle\Filesystem\TwigTemplateLocator;
 use HeimrichHannot\UtilsBundle\Dca\DcaUtil;
@@ -32,7 +31,7 @@ class WatchlistConfigContainer
     }
 
     /**
-     * @Callback(table="tl_watchlist_config", target="config.onsubmit")
+     * Callback(table="tl_watchlist_config", target="config.onsubmit")
      */
     public function setDateAdded(DataContainer $dc)
     {
@@ -40,7 +39,7 @@ class WatchlistConfigContainer
     }
 
     /**
-     * @Callback(table="tl_watchlist_config", target="config.oncopy")
+     * Callback(table="tl_watchlist_config", target="config.oncopy")
      */
     public function setDateAddedOnCopy($insertId, DataContainer $dc)
     {
@@ -48,7 +47,7 @@ class WatchlistConfigContainer
     }
 
     /**
-     * @Callback(table="tl_watchlist_config", target="fields.insertTagAddItemTemplate.options")
+     * Callback(table="tl_watchlist_config", target="fields.insertTagAddItemTemplate.options")
      */
     public function getInsertTagAddItemTemplates(DataContainer $dc)
     {
@@ -58,7 +57,7 @@ class WatchlistConfigContainer
     }
 
     /**
-     * @Callback(table="tl_watchlist_config", target="fields.watchlistContentTemplate.options")
+     * Callback(table="tl_watchlist_config", target="fields.watchlistContentTemplate.options")
      */
     public function getWatchlistContentTemplates(DataContainer $dc)
     {

--- a/src/DataContainer/WatchlistContainer.php
+++ b/src/DataContainer/WatchlistContainer.php
@@ -8,7 +8,6 @@
 
 namespace HeimrichHannot\WatchlistBundle\DataContainer;
 
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use HeimrichHannot\UtilsBundle\Choice\ModelInstanceChoice;
 use HeimrichHannot\UtilsBundle\Dca\DcaUtil;
@@ -27,7 +26,7 @@ class WatchlistContainer
     }
 
     /**
-     * @Callback(table="tl_watchlist", target="config.onsubmit")
+     * Callback(table="tl_watchlist", target="config.onsubmit")
      */
     public function setDateAdded(DataContainer $dc)
     {
@@ -35,7 +34,7 @@ class WatchlistContainer
     }
 
     /**
-     * @Callback(table="tl_watchlist", target="config.oncopy")
+     * Callback(table="tl_watchlist", target="config.oncopy")
      */
     public function setDateAddedOnCopy($insertId, DataContainer $dc)
     {
@@ -43,7 +42,7 @@ class WatchlistContainer
     }
 
     /**
-     * @Callback(table="tl_watchlist", target="fields.config.options")
+     * Callback(table="tl_watchlist", target="fields.config.options")
      */
     public function getWatchlistConfigs(DataContainer $dc)
     {

--- a/src/DataContainer/WatchlistContainer.php
+++ b/src/DataContainer/WatchlistContainer.php
@@ -15,8 +15,10 @@ use HeimrichHannot\UtilsBundle\Dca\DcaUtil;
 
 class WatchlistContainer
 {
-    protected DcaUtil             $dcaUtil;
-    protected ModelInstanceChoice $modelInstanceChoice;
+    /** @var DcaUtil */
+    protected $dcaUtil;
+    /** @var ModelInstanceChoice */
+    protected $modelInstanceChoice;
 
     public function __construct(DcaUtil $dcaUtil, ModelInstanceChoice $modelInstanceChoice)
     {

--- a/src/DataContainer/WatchlistItemContainer.php
+++ b/src/DataContainer/WatchlistItemContainer.php
@@ -9,7 +9,6 @@
 namespace HeimrichHannot\WatchlistBundle\DataContainer;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
-use Contao\CoreBundle\ServiceAnnotation\Callback;
 use Contao\DataContainer;
 use Contao\System;
 use HeimrichHannot\UtilsBundle\Choice\DataContainerChoice;
@@ -52,7 +51,7 @@ class WatchlistItemContainer
     }
 
     /**
-     * @Callback(table="tl_watchlist_item", target="list.sorting.child_record")
+     * Callback(table="tl_watchlist_item", target="list.sorting.child_record")
      */
     public function listChildren(array $row)
     {
@@ -87,7 +86,7 @@ class WatchlistItemContainer
     }
 
     /**
-     * @Callback(table="tl_watchlist_item", target="config.onsubmit")
+     * Callback(table="tl_watchlist_item", target="config.onsubmit")
      */
     public function setDateAdded(DataContainer $dc)
     {
@@ -95,7 +94,7 @@ class WatchlistItemContainer
     }
 
     /**
-     * @Callback(table="tl_watchlist_item", target="config.oncopy")
+     * Callback(table="tl_watchlist_item", target="config.oncopy")
      */
     public function setDateAddedOnCopy($insertId, DataContainer $dc)
     {
@@ -103,7 +102,7 @@ class WatchlistItemContainer
     }
 
     /**
-     * @Callback(table="tl_watchlist_item", target="fields.entityTable.options")
+     * Callback(table="tl_watchlist_item", target="fields.entityTable.options")
      */
     public function getDataContainers()
     {
@@ -111,7 +110,7 @@ class WatchlistItemContainer
     }
 
     /**
-     * @Callback(table="tl_watchlist_item", target="fields.entity.options")
+     * Callback(table="tl_watchlist_item", target="fields.entity.options")
      */
     public function getEntities(DataContainer $dc)
     {

--- a/src/DataContainer/WatchlistItemContainer.php
+++ b/src/DataContainer/WatchlistItemContainer.php
@@ -28,12 +28,18 @@ class WatchlistItemContainer
         self::TYPE_ENTITY,
     ];
 
-    protected ContaoFramework     $framework;
-    protected DcaUtil             $dcaUtil;
-    protected DataContainerChoice $dataContainerChoice;
-    protected ModelUtil           $modelUtil;
-    protected ModelInstanceChoice $modelInstanceChoice;
-    protected FileUtil            $fileUtil;
+    /** @var ContaoFramework */
+    protected $framework;
+    /** @var DcaUtil */
+    protected $dcaUtil;
+    /** @var DataContainerChoice */
+    protected $dataContainerChoice;
+    /** @var ModelUtil */
+    protected $modelUtil;
+    /** @var ModelInstanceChoice */
+    protected $modelInstanceChoice;
+    /** @var FileUtil */
+    protected $fileUtil;
 
     public function __construct(ContaoFramework $framework, DataContainerChoice $dataContainerChoice, ModelInstanceChoice $modelInstanceChoice, DcaUtil $dcaUtil, ModelUtil $modelUtil, FileUtil $fileUtil)
     {

--- a/src/Event/WatchlistItemDataEvent.php
+++ b/src/Event/WatchlistItemDataEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace HeimrichHannot\WatchlistBundle\Event;
+
+use HeimrichHannot\WatchlistBundle\Model\WatchlistConfigModel;
+use Symfony\Component\EventDispatcher\Event;
+
+class WatchlistItemDataEvent extends Event
+{
+
+    /**
+     * @var array
+     */
+    private $item;
+    /**
+     * @var WatchlistConfigModel
+     */
+    private $configModel;
+
+    public function __construct(array $item, WatchlistConfigModel $configModel)
+    {
+        $this->item = $item;
+        $this->configModel = $configModel;
+    }
+
+    /**
+     * @return array
+     */
+    public function getItem(): array
+    {
+        return $this->item;
+    }
+
+    /**
+     * @param array $item
+     */
+    public function setItem(array $item): void
+    {
+        $this->item = $item;
+    }
+
+    /**
+     * @return WatchlistConfigModel
+     */
+    public function getConfigModel(): WatchlistConfigModel
+    {
+        return $this->configModel;
+    }
+}

--- a/src/EventListener/Contao/LoadDataContainerListener.php
+++ b/src/EventListener/Contao/LoadDataContainerListener.php
@@ -12,11 +12,12 @@ use Contao\CoreBundle\ServiceAnnotation\Hook;
 use HeimrichHannot\UtilsBundle\Dca\DcaUtil;
 
 /**
- * @Hook("loadDataContainer")
+ * Hook("loadDataContainer")
  */
 class LoadDataContainerListener
 {
-    protected DcaUtil $dcaUtil;
+    /** @var DcaUtil  */
+    protected $dcaUtil;
 
     public function __construct(DcaUtil $dcaUtil)
     {

--- a/src/EventListener/Contao/ReplaceInsertTagsListener.php
+++ b/src/EventListener/Contao/ReplaceInsertTagsListener.php
@@ -21,15 +21,20 @@ use HeimrichHannot\WatchlistBundle\Util\WatchlistUtil;
 use Twig\Environment;
 
 /**
- * @Hook("replaceInsertTags")
+ * Hook("replaceInsertTags")
  */
 class ReplaceInsertTagsListener
 {
-    protected Environment         $twig;
-    protected WatchlistUtil       $watchlistUtil;
-    protected TwigTemplateLocator $twigTemplateLocator;
-    protected ModelUtil           $modelUtil;
-    protected DatabaseUtil        $databaseUtil;
+    /** @var Environment */
+    protected $twig;
+    /** @var WatchlistUtil */
+    protected $watchlistUtil;
+    /** @var TwigTemplateLocator */
+    protected $twigTemplateLocator;
+    /** @var ModelUtil */
+    protected $modelUtil;
+    /** @var DatabaseUtil */
+    protected $databaseUtil;
 
     public function __construct(
         Environment $twig,

--- a/src/EventListener/ListModifyQueryBuilderForCountEventListener.php
+++ b/src/EventListener/ListModifyQueryBuilderForCountEventListener.php
@@ -16,14 +16,18 @@ use HeimrichHannot\WatchlistBundle\Util\WatchlistUtil;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
 
 /**
- * @ServiceTag("kernel.event_listener", event="huh.list.event.list_modify_query_builder_for_count")
+ * ServiceTag("kernel.event_listener", event="huh.list.event.list_modify_query_builder_for_count")
  */
 class ListModifyQueryBuilderForCountEventListener
 {
-    protected ModelUtil     $modelUtil;
-    protected Request       $request;
-    protected DatabaseUtil  $databaseUtil;
-    protected WatchlistUtil $watchlistUtil;
+    /** @var ModelUtil */
+    protected $modelUtil;
+    /** @var Request */
+    protected $request;
+    /** @var DatabaseUtil */
+    protected $databaseUtil;
+    /** @var WatchlistUtil */
+    protected $watchlistUtil;
 
     public function __construct(ModelUtil $modelUtil, Request $request, DatabaseUtil $databaseUtil, WatchlistUtil $watchlistUtil)
     {

--- a/src/EventListener/ReaderModifyQueryBuilderEventListener.php
+++ b/src/EventListener/ReaderModifyQueryBuilderEventListener.php
@@ -16,14 +16,18 @@ use HeimrichHannot\WatchlistBundle\Util\WatchlistUtil;
 use Terminal42\ServiceAnnotationBundle\Annotation\ServiceTag;
 
 /**
- * @ServiceTag("kernel.event_listener", event="huh.reader.event.reader_modify_query_builder")
+ * ServiceTag("kernel.event_listener", event="huh.reader.event.reader_modify_query_builder")
  */
 class ReaderModifyQueryBuilderEventListener
 {
-    protected ModelUtil     $modelUtil;
-    protected Request       $request;
-    protected DatabaseUtil  $databaseUtil;
-    protected WatchlistUtil $watchlistUtil;
+    /** @var ModelUtil */
+    protected $modelUtil;
+    /** @var Request */
+    protected $request;
+    /** @var DatabaseUtil */
+    protected $databaseUtil;
+    /** @var WatchlistUtil */
+    protected $watchlistUtil;
 
     public function __construct(ModelUtil $modelUtil, Request $request, DatabaseUtil $databaseUtil, WatchlistUtil $watchlistUtil)
     {

--- a/src/Module/ShareListModule.php
+++ b/src/Module/ShareListModule.php
@@ -8,12 +8,17 @@ use HeimrichHannot\WatchlistBundle\Controller\FrontendModule\ShareListModuleCont
 
 class ShareListModule extends Module
 {
+    /**
+     * Template
+     * @var string
+     */
+    protected $strTemplate = 'mod_watchlist_share_list';
 
     protected function compile()
     {
         $request = System::getContainer()->get('request_stack')->getCurrentRequest();
         if ($request) {
-            $module = System::getContainer()->get(ShareListModuleController::class)->getResponse($this->Template, $this->getModel(), $request);
+            System::getContainer()->get(ShareListModuleController::class)->getResponse($this->Template, $this->getModel(), $request);
         }
     }
 }

--- a/src/Module/ShareListModule.php
+++ b/src/Module/ShareListModule.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace HeimrichHannot\WatchlistBundle\Module;
+
+use Contao\Module;
+use Contao\System;
+use HeimrichHannot\WatchlistBundle\Controller\FrontendModule\ShareListModuleController;
+
+class ShareListModule extends Module
+{
+
+    protected function compile()
+    {
+        $request = System::getContainer()->get('request_stack')->getCurrentRequest();
+        if ($request) {
+            $module = System::getContainer()->get(ShareListModuleController::class)->getResponse($this->Template, $this->getModel(), $request);
+        }
+    }
+}

--- a/src/Module/WatchlistModule.php
+++ b/src/Module/WatchlistModule.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace HeimrichHannot\WatchlistBundle\Module;
+
+use Contao\Module;
+use Contao\System;
+use HeimrichHannot\WatchlistBundle\Controller\FrontendModule\WatchlistModuleController;
+
+class WatchlistModule extends Module
+{
+
+    protected function compile()
+    {
+        $request = System::getContainer()->get('request_stack')->getCurrentRequest();
+        if ($request) {
+            $module = System::getContainer()->get(WatchlistModuleController::class)->getResponse($this->Template, $this->getModel(), $request);
+        }
+    }
+}

--- a/src/Module/WatchlistModule.php
+++ b/src/Module/WatchlistModule.php
@@ -4,16 +4,25 @@ namespace HeimrichHannot\WatchlistBundle\Module;
 
 use Contao\Module;
 use Contao\System;
+use HeimrichHannot\UtilsBundle\Util\Utils;
 use HeimrichHannot\WatchlistBundle\Controller\FrontendModule\WatchlistModuleController;
 
 class WatchlistModule extends Module
 {
+    /**
+     * Template
+     * @var string
+     */
+    protected $strTemplate = 'mod_watchlist';
 
     protected function compile()
     {
+        if (System::getContainer()->get(Utils::class)->container()->isBackend()) {
+            return;
+        }
         $request = System::getContainer()->get('request_stack')->getCurrentRequest();
         if ($request) {
-            $module = System::getContainer()->get(WatchlistModuleController::class)->getResponse($this->Template, $this->getModel(), $request);
+            System::getContainer()->get(WatchlistModuleController::class)->getResponse($this->Template, $this->getModel(), $request);
         }
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -4,12 +4,7 @@ services:
     autowire: true
 
   HeimrichHannot\WatchlistBundle\:
-    resource: '../../{Controller,DataContainer,EventListener,Migration,Util}/*'
-
-  HeimrichHannot\WatchlistBundle\Migration\:
-    resource: '../../Migration/*'
-    tags:
-      - { name: contao.migration }
+    resource: '../../{Controller,DataContainer,EventListener,Util}/*'
 
   HeimrichHannot\WatchlistBundle\EventListener\ListModifyQueryBuilderForCountEventListener:
     tags:

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -10,3 +10,11 @@ services:
     resource: '../../Migration/*'
     tags:
       - { name: contao.migration }
+
+  HeimrichHannot\WatchlistBundle\EventListener\ListModifyQueryBuilderForCountEventListener:
+    tags:
+      - { name: kernel.event_listener, event: huh.list.event.list_modify_query_builder_for_count, method: __invoke }
+
+  HeimrichHannot\WatchlistBundle\EventListener\ReaderModifyQueryBuilderEventListener:
+    tags:
+      - { name: kernel.event_listener, event: huh.reader.event.reader_modify_query_builder, method: __invoke }

--- a/src/Resources/config/services_migration.yml
+++ b/src/Resources/config/services_migration.yml
@@ -1,0 +1,7 @@
+services:
+  _defaults:
+    autoconfigure: true
+    autowire: true
+
+  HeimrichHannot\WatchlistBundle\Migration:
+    resource: '../../Migration/*'

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -34,8 +34,8 @@ $GLOBALS['TL_MODELS']['tl_watchlist_config'] = WatchlistConfigModel::class;
 /*
  * Frontend modules
  */
-$GLOBALS['FE_MOD']['list']['miscellaneous'][ShareListModuleController::TYPE] = ShareListModule::class;
-$GLOBALS['FE_MOD']['list']['miscellaneous'][WatchlistModuleController::TYPE] = WatchlistModule::class;
+$GLOBALS['FE_MOD']['miscellaneous'][ShareListModuleController::TYPE] = ShareListModule::class;
+$GLOBALS['FE_MOD']['miscellaneous'][WatchlistModuleController::TYPE] = WatchlistModule::class;
 
 /*
  * Hooks

--- a/src/Resources/contao/config/config.php
+++ b/src/Resources/contao/config/config.php
@@ -6,6 +6,16 @@
  * @license LGPL-3.0-or-later
  */
 
+use HeimrichHannot\WatchlistBundle\Controller\FrontendModule\ShareListModuleController;
+use HeimrichHannot\WatchlistBundle\Controller\FrontendModule\WatchlistModuleController;
+use HeimrichHannot\WatchlistBundle\EventListener\Contao\LoadDataContainerListener;
+use HeimrichHannot\WatchlistBundle\EventListener\Contao\ReplaceInsertTagsListener;
+use HeimrichHannot\WatchlistBundle\Model\WatchlistConfigModel;
+use HeimrichHannot\WatchlistBundle\Model\WatchlistItemModel;
+use HeimrichHannot\WatchlistBundle\Model\WatchlistModel;
+use HeimrichHannot\WatchlistBundle\Module\ShareListModule;
+use HeimrichHannot\WatchlistBundle\Module\WatchlistModule;
+
 $GLOBALS['BE_MOD']['system']['watchlist'] = [
     'tables' => ['tl_watchlist', 'tl_watchlist_item'],
 ];
@@ -17,6 +27,18 @@ $GLOBALS['BE_MOD']['system']['watchlist_config'] = [
 /*
  * Model
  */
-$GLOBALS['TL_MODELS']['tl_watchlist'] = \HeimrichHannot\WatchlistBundle\Model\WatchlistModel::class;
-$GLOBALS['TL_MODELS']['tl_watchlist_item'] = \HeimrichHannot\WatchlistBundle\Model\WatchlistItemModel::class;
-$GLOBALS['TL_MODELS']['tl_watchlist_config'] = \HeimrichHannot\WatchlistBundle\Model\WatchlistConfigModel::class;
+$GLOBALS['TL_MODELS']['tl_watchlist'] = WatchlistModel::class;
+$GLOBALS['TL_MODELS']['tl_watchlist_item'] = WatchlistItemModel::class;
+$GLOBALS['TL_MODELS']['tl_watchlist_config'] = WatchlistConfigModel::class;
+
+/*
+ * Frontend modules
+ */
+$GLOBALS['FE_MOD']['list']['miscellaneous'][ShareListModuleController::TYPE] = ShareListModule::class;
+$GLOBALS['FE_MOD']['list']['miscellaneous'][WatchlistModuleController::TYPE] = WatchlistModule::class;
+
+/*
+ * Hooks
+ */
+$GLOBALS['TL_HOOKS']['loadDataContainer'][] = [LoadDataContainerListener::class, '__invoke'];
+$GLOBALS['TL_HOOKS']['replaceInsertTags'][] = [ReplaceInsertTagsListener::class, '__invoke'];

--- a/src/Resources/contao/dca/tl_watchlist.php
+++ b/src/Resources/contao/dca/tl_watchlist.php
@@ -6,6 +6,8 @@
  * @license LGPL-3.0-or-later
  */
 
+use HeimrichHannot\WatchlistBundle\DataContainer\WatchlistContainer;
+
 $GLOBALS['TL_DCA']['tl_watchlist'] = [
     'config' => [
         'dataContainer' => 'Table',
@@ -15,6 +17,12 @@ $GLOBALS['TL_DCA']['tl_watchlist'] = [
             'keys' => [
                 'id' => 'primary',
             ],
+        ],
+        'onsubmit_callback' => [
+            [WatchlistContainer::class, 'setDateAdded']
+        ],
+        'oncopy_callback' => [
+            [WatchlistContainer::class, 'setDateAddedOnCopy']
         ],
     ],
     'list' => [
@@ -99,6 +107,7 @@ $GLOBALS['TL_DCA']['tl_watchlist'] = [
             'exclude' => true,
             'filter' => true,
             'inputType' => 'select',
+            'options_callback' => [WatchlistContainer::class, 'getWatchlistConfigs'],
             'eval' => ['tl_class' => 'w50', 'mandatory' => true, 'includeBlankOption' => true, 'chosen' => true],
             'sql' => "varchar(64) NOT NULL default ''",
         ],

--- a/src/Resources/contao/dca/tl_watchlist_config.php
+++ b/src/Resources/contao/dca/tl_watchlist_config.php
@@ -6,6 +6,8 @@
  * @license LGPL-3.0-or-later
  */
 
+use HeimrichHannot\WatchlistBundle\DataContainer\WatchlistConfigContainer;
+
 $GLOBALS['TL_DCA']['tl_watchlist_config'] = [
     'config' => [
         'dataContainer' => 'Table',
@@ -13,6 +15,12 @@ $GLOBALS['TL_DCA']['tl_watchlist_config'] = [
             'keys' => [
                 'id' => 'primary',
             ],
+        ],
+        'onsubmit_callback' => [
+            [WatchlistConfigContainer::class, 'setDateAdded']
+        ],
+        'oncopy_callback' => [
+            [WatchlistConfigContainer::class, 'setDateAddedOnCopy']
         ],
     ],
     'list' => [
@@ -92,6 +100,7 @@ $GLOBALS['TL_DCA']['tl_watchlist_config'] = [
             'exclude' => true,
             'filter' => true,
             'inputType' => 'select',
+            'options_callback' => [WatchlistConfigContainer::class, 'getInsertTagAddItemTemplates'],
             'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true, 'chosen' => true],
             'sql' => "varchar(255) NOT NULL default ''",
         ],
@@ -100,6 +109,7 @@ $GLOBALS['TL_DCA']['tl_watchlist_config'] = [
             'exclude' => true,
             'filter' => true,
             'inputType' => 'select',
+            'options_callback' => [WatchlistConfigContainer::class, 'getWatchlistContentTemplates'],
             'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true, 'chosen' => true],
             'sql' => "varchar(255) NOT NULL default ''",
         ],

--- a/src/Resources/contao/dca/tl_watchlist_item.php
+++ b/src/Resources/contao/dca/tl_watchlist_item.php
@@ -6,6 +6,8 @@
  * @license LGPL-3.0-or-later
  */
 
+use HeimrichHannot\WatchlistBundle\DataContainer\WatchlistItemContainer;
+
 $GLOBALS['TL_DCA']['tl_watchlist_item'] = [
     'config' => [
         'dataContainer' => 'Table',
@@ -14,6 +16,12 @@ $GLOBALS['TL_DCA']['tl_watchlist_item'] = [
             'keys' => [
                 'id' => 'primary',
             ],
+        ],
+        'onsubmit_callback' => [
+            [WatchlistItemContainer::class, 'setDateAdded']
+        ],
+        'oncopy_callback' => [
+            [WatchlistItemContainer::class, 'setDateAddedOnCopy']
         ],
     ],
     'list' => [
@@ -26,6 +34,7 @@ $GLOBALS['TL_DCA']['tl_watchlist_item'] = [
             'fields' => ['dateAdded'],
             'headerFields' => ['title'],
             'panelLayout' => 'filter;sort,search,limit',
+            'child_record_callback' => [WatchlistItemContainer::class, 'listChildren']
         ],
         'global_operations' => [
             'all' => [
@@ -59,8 +68,8 @@ $GLOBALS['TL_DCA']['tl_watchlist_item'] = [
             'type',
         ],
         'default' => '{general_legend},title,type;',
-        \HeimrichHannot\WatchlistBundle\DataContainer\WatchlistItemContainer::TYPE_FILE => '{general_legend},title,type;{reference_legend},file;{context_legend},page,autoItem;',
-        \HeimrichHannot\WatchlistBundle\DataContainer\WatchlistItemContainer::TYPE_ENTITY => '{general_legend},title,type;{reference_legend},entityTable,entity,entityUrl,entityFile;{context_legend},page,autoItem;',
+        WatchlistItemContainer::TYPE_FILE => '{general_legend},title,type;{reference_legend},file;{context_legend},page,autoItem;',
+        WatchlistItemContainer::TYPE_ENTITY => '{general_legend},title,type;{reference_legend},entityTable,entity,entityUrl,entityFile;{context_legend},page,autoItem;',
     ],
     'fields' => [
         'id' => [
@@ -95,7 +104,7 @@ $GLOBALS['TL_DCA']['tl_watchlist_item'] = [
             'exclude' => true,
             'filter' => true,
             'inputType' => 'select',
-            'options' => \HeimrichHannot\WatchlistBundle\DataContainer\WatchlistItemContainer::TYPES,
+            'options' => WatchlistItemContainer::TYPES,
             'reference' => &$GLOBALS['TL_LANG']['tl_watchlist_item']['reference'],
             'eval' => ['tl_class' => 'w50', 'mandatory' => true, 'includeBlankOption' => true, 'submitOnChange' => true],
             'sql' => "varchar(64) NOT NULL default ''",
@@ -115,6 +124,7 @@ $GLOBALS['TL_DCA']['tl_watchlist_item'] = [
         'entityTable' => [
             'label' => &$GLOBALS['TL_LANG']['tl_watchlist_item']['entityTable'],
             'inputType' => 'select',
+            'options_callback' => [WatchlistItemContainer::class, 'getDataContainers'],
             'eval' => [
                 'tl_class' => 'w50',
                 'chosen' => true,
@@ -127,6 +137,7 @@ $GLOBALS['TL_DCA']['tl_watchlist_item'] = [
         'entity' => [
             'label' => &$GLOBALS['TL_LANG']['tl_watchlist_item']['entity'],
             'inputType' => 'select',
+            'options_callback' => [WatchlistItemContainer::class, 'getEntities'],
             'eval' => ['tl_class' => 'w50', 'chosen' => true, 'includeBlankOption' => true, 'mandatory' => true],
             'sql' => "int(10) unsigned NOT NULL default '0'",
         ],

--- a/src/Resources/views/insert_tag/_watchlist_insert_tag_add_item_default.html.twig
+++ b/src/Resources/views/insert_tag/_watchlist_insert_tag_add_item_default.html.twig
@@ -1,8 +1,10 @@
 <a href="{{ href }}" class="watchlist-add-item{{ isAdded ? ' added' : ''}} {% block cssClasses %}{% endblock %}"
    data-hash="{{ hash }}"
    data-post-data="{{ postData|json_encode|e('html_attr') }}"
-   data-item-added-message="{{ ('huh.watchlist.misc.' ~ postData.type ~ '_added_successfully')|trans }}"
-   data-add-item-message="{{ 'huh.watchlist.misc.add_to_watchlist'|trans }}"
-   data-delete-item-message="{{ 'huh.watchlist.misc.delete_from_watchlist'|trans }}">
+   data-item-added-message="{% block item_added_message %}{{ ('huh.watchlist.misc.' ~ postData.type ~ '_added_successfully')|trans }}{% endblock %}"
+   data-add-item-message="{% block add_item_message %}{{ 'huh.watchlist.misc.add_to_watchlist'|trans }}{% endblock %}"
+   data-delete-item-message="{% block delete_item_message %}{{ 'huh.watchlist.misc.delete_from_watchlist'|trans }}{% endblock %}">
+    {%- block text -%}
     {{ ('huh.watchlist.misc.' ~ (isAdded ? 'delete_from_watchlist' : 'add_to_watchlist'))|trans }}
+    {%- endblock -%}
 </a>

--- a/src/Util/WatchlistUtil.php
+++ b/src/Util/WatchlistUtil.php
@@ -291,7 +291,7 @@ class WatchlistUtil
                         $cleanedItem['entityTable'] = $item['entityTable'];
                         $cleanedItem['entity'] = $item['entity'];
                         $cleanedItem['entityUrl'] = $item['entityUrl'];
-                        $cleanedItem['entityFile'] = StringUtil::binToUuid($item['entityFile']);
+                        $cleanedItem['entityFile'] = $item['entityFile'] ? StringUtil::binToUuid($item['entityFile']) : '';
 
                         $existing = $this->databaseUtil->findResultByPk($cleanedItem['entityTable'], $cleanedItem['entity']);
 

--- a/src/Util/WatchlistUtil.php
+++ b/src/Util/WatchlistUtil.php
@@ -34,13 +34,20 @@ use HeimrichHannot\WatchlistBundle\Model\WatchlistModel;
 
 class WatchlistUtil
 {
-    protected ContaoFramework $framework;
-    protected DatabaseUtil    $DatabaseUtil;
-    protected Utils           $utils;
-    protected ModelUtil       $modelUtil;
-    protected UrlUtil         $urlUtil;
-    protected FileUtil        $fileUtil;
-    protected ImageUtil       $imageUtil;
+    /** @var ContaoFramework */
+    protected $framework;
+    /** @var DatabaseUtil */
+    protected $DatabaseUtil;
+    /** @var Utils */
+    protected $utils;
+    /** @var ModelUtil */
+    protected $modelUtil;
+    /** @var UrlUtil */
+    protected $urlUtil;
+    /** @var FileUtil */
+    protected $fileUtil;
+    /** @var ImageUtil */
+    protected $imageUtil;
 
     public function __construct(
         ContaoFramework $framework,


### PR DESCRIPTION
Changelog:
- Added: WatchlistItemDataEvent
- Changed: migrated code to be compatible with contao 4.4 / Symfony 3.4
- Changed: migrated code to be compatible with php 7.3
- Changed: added some template blocks
- Fixed: getCurrentWatchlist()
- Fixed: foxy not enabled